### PR TITLE
remove channel config

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,6 @@ docker run -d --env-file dot.env leonisandco/rds-mysql-slowlog-monitor:latest
 
 => [fluent-plugin-rds-slowlogのOverview](https://github.com/kenjiskywalker/fluent-plugin-rds-slowlog#overview)
 
-## 環境変数にslackのchannel名は不要では?
-
-=> [fluent-plugin-slackのissue 19](https://github.com/sowawa/fluent-plugin-slack/issues/19)
-
 # License
 
 MIT

--- a/fluent.conf
+++ b/fluent.conf
@@ -47,7 +47,6 @@
     @type slack
 
     webhook_url "#{ENV['SLACK_WEBHOOK_URL']}"
-    channel "#{ENV['SLACK_CHANNEL']}"
     color danger
     message "*[Host/User]* %s\r\n *[Query Time]* %s\r\n *[Lock Time]* %s\r\n *[Rows sent]* %s\r\n *[Rows Examined]* %s\r\n *[SQL]* %s \r\n"
     message_keys user_host,query_time,lock_time,rows_sent,rows_examined,fingerprint


### PR DESCRIPTION
With fluent-plugin-slack after 0.6.6, webhook does not require channel config. 🎉 

So this PR update the gem and remove channel config from fluent.config.